### PR TITLE
Add const keywords to parameters of setTime() and setDate() in BM8563

### DIFF
--- a/src/utility/BM8563.cpp
+++ b/src/utility/BM8563.cpp
@@ -103,7 +103,7 @@ void BM8563::getTime(rtc_time_t *time)
     time->hour = Bcd2ToByte(buf[2] & 0x3f);
 }
 
-void BM8563::setTime(rtc_time_t *time)
+void BM8563::setTime(const rtc_time_t *time)
 {
 
     if (time == NULL)
@@ -150,7 +150,7 @@ void BM8563::getDate(rtc_date_t *date)
     }
 }
 
-void BM8563::setDate(rtc_date_t *date)
+void BM8563::setDate(const rtc_date_t *date)
 {
 
     if (date == NULL)

--- a/src/utility/BM8563.h
+++ b/src/utility/BM8563.h
@@ -32,8 +32,8 @@ public:
     uint8_t readReg(uint8_t reg);
     void getTime(void);
 
-    void setTime(rtc_time_t *time);
-    void setDate(rtc_date_t *date);
+    void setTime(const rtc_time_t *time);
+    void setDate(const rtc_date_t *date);
 
     void getTime(rtc_time_t *time);
     void getDate(rtc_date_t *date);


### PR DESCRIPTION
Parameters of setter functions can be `const`.