### PR TITLE
Fix unused variable warnings

### DIFF
--- a/src/M5EPD_Canvas.cpp
+++ b/src/M5EPD_Canvas.cpp
@@ -792,7 +792,9 @@ bool M5EPD_Canvas::drawBmpFile(fs::FS &fs, const char *path, uint16_t x, uint16_
     uint16_t w, h, row, col;
     uint8_t r, g, b;
 
+#if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_DEBUG
     uint32_t startTime = millis();
+#endif
 
     if (read16(bmpFS) == 0x4D42)
     {

--- a/src/font_render.c
+++ b/src/font_render.c
@@ -29,7 +29,9 @@ static esp_err_t font_cache_init(font_render_t *render)
 {
     font_cache_destroy(render);
 
+#if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_DEBUG
     uint32_t heapsize = esp_get_free_heap_size();
+#endif
     render->max_pixel_width = (render->pixel_size * (render->font_face->ft_face->bbox.xMax - render->font_face->ft_face->bbox.xMin)) / render->font_face->ft_face->units_per_EM + 1;
     render->max_pixel_height = (render->pixel_size * (render->font_face->ft_face->bbox.yMax - render->font_face->ft_face->bbox.yMin)) / render->font_face->ft_face->units_per_EM + 1;
     // render->origin = (render->pixel_size * (-render->font_face->ft_face->bbox.yMin)) / render->font_face->ft_face->units_per_EM;


### PR DESCRIPTION
Fixed following warnings about unused variables.
`startTime` and `headsize` are now defined when `-DCORE_DEBUG_LEVEL` >=4.

```
.pio\libdeps\m5paper-test\M5EPD\src\font_render.c: In function 'font_cache_init':
.pio\libdeps\m5paper-test\M5EPD\src\font_render.c:32:14: warning: unused variable 'heapsize' [-Wunused-variable]
     uint32_t heapsize = esp_get_free_heap_size();
              ^
.pio\libdeps\m5paper-test\M5EPD\src\M5EPD_Canvas.cpp: In member function 'bool M5EPD_Canvas::drawBmpFile(fs::FS&, const char*, uint16_t, uint16_t)':
.pio\libdeps\m5paper-test\M5EPD\src\M5EPD_Canvas.cpp:793:14: warning: unused variable 'startTime' [-Wunused-variable]
     uint32_t startTime = millis();
              ^
```