### PR TITLE
 Add a destructor to M5EPD

### DIFF
--- a/src/M5EPD.cpp
+++ b/src/M5EPD.cpp
@@ -7,11 +7,8 @@
 #define SCALE 0.5//0.78571429
 #define ADC_FILTER_SAMPLE 8
 
-
-M5EPD::M5EPD()
+M5EPD::M5EPD() : _is_adc_start(false), _isInited(false), _adc_chars(nullptr)
 {
-    _isInited = false;
-    _is_adc_start = false;
 }
 
 /** @brief Initialize the power supply, screen and other peripherals

--- a/src/M5EPD.h
+++ b/src/M5EPD.h
@@ -39,6 +39,11 @@ class M5EPD
 {
 public:
     M5EPD();
+    ~M5EPD()
+    {
+        if (_adc_chars != nullptr)
+            free(_adc_chars);
+    }
     void begin(bool touchEnable = true, bool SDEnable = true, bool SerialEnable = true, bool BatteryADCEnable = true, bool I2CEnable = false);
     void update();
     void enableEXTPower() { digitalWrite(M5EPD_EXT_PWR_EN_PIN, 1); }
@@ -52,9 +57,9 @@ public:
     uint32_t getBatteryVoltage();
 
     void shutdown();
-    int shutdown( int seconds );
-    int shutdown( const rtc_time_t &RTC_TimeStruct);
-    int shutdown( const rtc_date_t &RTC_DateStruct, const rtc_time_t &RTC_TimeStruct);
+    int shutdown(int seconds);
+    int shutdown(const rtc_time_t &RTC_TimeStruct);
+    int shutdown(const rtc_date_t &RTC_DateStruct, const rtc_time_t &RTC_TimeStruct);
 
     Button BtnL = Button(M5EPD_KEY_LEFT_PIN, true, 10);
     Button BtnP = Button(M5EPD_KEY_PUSH_PIN, true, 10);


### PR DESCRIPTION
This PR addresses a bug that `_adc_chars` is not released.