### PR TITLE
Add EPD power mode set functions

### DIFF
--- a/src/M5EPD_Driver.cpp
+++ b/src/M5EPD_Driver.cpp
@@ -537,6 +537,45 @@ m5epd_err_t M5EPD_Driver::SetTargetMemoryAddr(uint32_t tar_addr)
 }
 
 
+/** @brief Set power mode to Active
+  * @retval m5epd_err_t
+  */
+m5epd_err_t M5EPD_Driver::Active(void)
+{
+    StartSPI();
+    CHECK(WriteCommand(IT8951_TCON_SYS_RUN));
+    EndSPI();
+
+    return M5EPD_OK;
+}
+
+/** @brief Set power mode to StandBy
+  * @retval m5epd_err_t
+  */
+m5epd_err_t M5EPD_Driver::StandBy(void)
+{
+    StartSPI();
+    CHECK(WriteCommand(IT8951_TCON_STANDBY));
+    EndSPI();
+    CHECK(WaitBusy());
+
+    return M5EPD_OK;
+}
+
+/** @brief Set power mode to Sleep
+  * @retval m5epd_err_t
+  */
+m5epd_err_t M5EPD_Driver::Sleep(void)
+{
+    StartSPI();
+    CHECK(WriteCommand(IT8951_TCON_SLEEP));
+    EndSPI();
+    CHECK(WaitBusy());
+
+    return M5EPD_OK;
+}
+
+
 m5epd_err_t M5EPD_Driver::WriteReg(uint16_t addr, uint16_t data)
 {
     CHECK(WriteCommand(0x0011)); //tcon write reg command

--- a/src/M5EPD_Driver.h
+++ b/src/M5EPD_Driver.h
@@ -120,6 +120,10 @@ public:
     SPIClass* GetSPI(void) {return _epd_spi;}
     void SetColorReverse(bool is_reverse);
 
+    m5epd_err_t Active(void);
+    m5epd_err_t StandBy(void);
+    m5epd_err_t Sleep(void);
+
 private:
     void ResetDriver(void);
     m5epd_err_t GetSysInfo(void);


### PR DESCRIPTION
In M5Paper, IT8591 (EPD Controller) consumes 50 - 70mA in the `Active` power mode.
When frequent screen redraw is not needed, it is useful to turn the IT8591 power mode to `StandBy` or `Sleep` to reduce this power consumption. It significantly extend battery life in interactive applications that requires partial screen update (e.g. touch UI).

This adds the `StandBy()`, `Sleep()`, and `Active()` functions to the `M5EPD_Driver` class.

Applications can call them like:
```c++
  M5.EPD.Sleep();  // reduces power consumption of IT8591
  wait_until_screen_touched();
  M5.EPD.Active();
  redraw_touched_button_with_inverted_color();
  ...
```