### PR TITLE
Commented out [no]interrupts that cause crashes

### DIFF
--- a/src/utility/GT911.cpp
+++ b/src/utility/GT911.cpp
@@ -26,9 +26,9 @@ GT911::GT911() {
 
 volatile uint8_t gt911_irq_trigger = 0;
 void ICACHE_RAM_ATTR ___GT911IRQ___() {
-    noInterrupts();
+    //noInterrupts();
     gt911_irq_trigger = 1;
-    interrupts();
+    //interrupts();
 }
 
 esp_err_t GT911::begin(uint8_t pin_sda, uint8_t pin_scl, uint8_t pin_int) {


### PR DESCRIPTION
I commented out these calls to noInterrupts and interrupts() as they lead to crashes that stop happening when these are commented out.  I think they provide no benefit and shouldn't be there.  Whether interrupts are enabled has no effect on setting a byte size integer to a constant value